### PR TITLE
feat: load ha token from runtime config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+
+# Runtime config injected during build
+public/app-config.json
+

--- a/.woodpecker/pipeline.yml
+++ b/.woodpecker/pipeline.yml
@@ -39,11 +39,8 @@ steps:
       - pnpm test:coverage
       - cp .env.example .env || true
       - pnpm build
+      - printf '{\n  "haToken": "%s"\n}\n' "$HA_TOKEN" > dist/app-config.json
       - cd dist
-      - |
-        for file in assets/index-*.js; do
-          node -e "const fs=require('fs'); const token=process.env.HA_TOKEN; let c=fs.readFileSync('$file','utf8'); c=c.replace(/your_long_lived_access_token_here/g, token); fs.writeFileSync('$file', c);"
-        done
       # Install smbclient
       - apt-get update && apt-get install -y smbclient
       # Delete all files and directories recursively, then upload

--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ This application connects to a Home Assistant instance via WebSockets and displa
 2. Install dependencies:
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 3. Configure environment variables:
-
    - Copy the example environment file:
      ```bash
      cp .env.example .env
@@ -55,12 +54,12 @@ This application connects to a Home Assistant instance via WebSockets and displa
 4. Start the development server:
 
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
 5. Build for production:
    ```bash
-   npm run build
+   pnpm build
    ```
 
 ### OBS Studio Integration
@@ -69,7 +68,6 @@ This application connects to a Home Assistant instance via WebSockets and displa
 2. For local development:
    - Use the URL provided by the Vite dev server (typically http://localhost:5173/)
 3. For production:
-
    - Host the built files on a web server and use that URL
    - Or use the "Local File" option and point to the index.html in your dist folder
 
@@ -95,11 +93,26 @@ body {
 | ------------------ | -------------------------------------- | ------------ |
 | `VITE_HA_TOKEN`    | Home Assistant long-lived access token | -            |
 | `VITE_HA_DEV_HOST` | Host IP/domain for development         | 192.168.0.13 |
-| `VITE_HA_PORT`     | Port for Home Assistant                | 8123         |
+| `VITE_HA_DEV_PORT` | Dev server websocket port              | 8123         |
+| `VITE_HA_PORT`     | Port for Home Assistant (prod)         | 8123         |
+
+### Runtime token configuration
+
+For production builds the overlay now reads `app-config.json` at runtime.
+Create `public/app-config.json` (or copy `public/app-config.example.json`) with:
+
+```json
+{
+  "haToken": "your_long_lived_access_token_here"
+}
+```
+
+When deploying via Woodpecker the pipeline writes this file automatically using the `HA_TOKEN` secret.
+If the file is missing, the overlay falls back to the compile-time `VITE_HA_TOKEN` env variable (useful for local dev).
 
 ### Development Mode
 
-When in development mode (`npm run dev`), you can:
+When in development mode (`pnpm dev`), you can:
 
 **Development Panel**: A control panel will appear in the top-left corner of the screen during development. It allows you to:
 

--- a/public/app-config.example.json
+++ b/public/app-config.example.json
@@ -1,0 +1,3 @@
+{
+  "haToken": "your_long_lived_access_token_here"
+}

--- a/src/composables/useRuntimeConfig.ts
+++ b/src/composables/useRuntimeConfig.ts
@@ -1,0 +1,46 @@
+import { ref } from 'vue';
+
+type RuntimeConfig = {
+  haToken?: string;
+};
+
+const runtimeConfig = ref<RuntimeConfig | null>(null);
+let fetchPromise: Promise<RuntimeConfig | null> | null = null;
+
+const fetchRuntimeConfig = async (): Promise<RuntimeConfig | null> => {
+  if (runtimeConfig.value) {
+    return runtimeConfig.value;
+  }
+
+  if (fetchPromise) {
+    return fetchPromise;
+  }
+
+  fetchPromise = fetch('/app-config.json', { cache: 'no-cache' })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Config request failed with status ${response.status}`);
+      }
+      return (await response.json()) as RuntimeConfig;
+    })
+    .then(config => {
+      runtimeConfig.value = config;
+      return config;
+    })
+    .catch(error => {
+      console.warn('[RuntimeConfig] No app-config.json available, falling back to env', error);
+      runtimeConfig.value = null;
+      return null;
+    })
+    .finally(() => {
+      fetchPromise = null;
+    });
+
+  return fetchPromise;
+};
+
+export const getHaToken = async (): Promise<string | null> => {
+  const config = await fetchRuntimeConfig();
+  const envFallback = import.meta.env.VITE_HA_TOKEN as string | undefined;
+  return config?.haToken ?? envFallback ?? null;
+};


### PR DESCRIPTION
## Summary
- fetch Home Assistant token from runtime app-config.json (with env fallback)
- ship public/app-config.example.json for local overrides
- adjust Woodpecker deploy to write dist/app-config.json and stop regexing bundles
- tweak README/docs + tests for the new config flow

## Testing
- pnpm lint
- pnpm test:coverage
- pnpm build