### PR TITLE
docs: update Node.js version requirement to 18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This application connects to a Home Assistant instance via WebSockets and displa
 
 ### Prerequisites
 
-- Node.js 16+ and npm
+- Node.js 18+ and npm
 - Home Assistant instance with long-lived access token
 - OBS Studio (for streaming/recording)
 


### PR DESCRIPTION
The project uses Vite 7, Vue 3.5, and @types/node 24 which all require Node.js 18+. The README previously stated 16+.

～(◕‿◕✿) spotted by Kongroo during Friday review!